### PR TITLE
CMake: Use root project identification and make proper options for install + shared/static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,24 @@ set(GLM_VERSION ${GLM_VERSION_MAJOR}.${GLM_VERSION_MINOR}.${GLM_VERSION_PATCH}.$
 project(glm VERSION ${GLM_VERSION} LANGUAGES CXX)
 message(STATUS "GLM: Version " ${GLM_VERSION})
 
+option(GLM_INSTALL "Generate the install target for GLM" ${GLM_ROOT_PROJECT})
+option(GLM_BUILD_STATIC_LIBS "Build static library" ${BUILD_STATIC_LIBS})
+option(GLM_BUILD_SHARED_LIBS "Build shared library" ${BUILD_SHARED_LIBS})
+
 add_subdirectory(glm)
 add_library(glm::glm ALIAS glm)
 
-if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+if(NOT DEFINED GLM_ROOT_PROJECT)
+	if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+		set(GLM_ROOT_PROJECT ON)
+	else()
+		set(GLM_ROOT_PROJECT OFF)
+	endif()
+endif()
 
+if(GLM_INSTALL)
+
+	message(STATUS "Generating GLM installation")
 	include(CPack)
 	install(DIRECTORY glm DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} PATTERN "CMakeLists.txt" EXCLUDE)
 	install(EXPORT glm FILE glmConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glm NAMESPACE glm::)
@@ -28,12 +41,12 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
 	write_basic_package_version_file("glmConfigVersion.cmake" COMPATIBILITY AnyNewerVersion)
 	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/glmConfigVersion.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/glm)
 
-	include(CTest)
-	if(BUILD_TESTING)
+	if(GLM_BUILD_TESTING)
+		include(CTest)
 		add_subdirectory(test)
 	endif()
 
-endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
 
 if (NOT TARGET uninstall)
 configure_file(cmake/cmake_uninstall.cmake.in

--- a/glm/CMakeLists.txt
+++ b/glm/CMakeLists.txt
@@ -53,7 +53,7 @@ target_include_directories(glm INTERFACE
 
 install(TARGETS glm EXPORT glm)
 
-if(BUILD_STATIC_LIBS)
+if(GLM_BUILD_STATIC_LIBS)
 add_library(glm_static STATIC ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
 	${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
 	${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
@@ -63,9 +63,19 @@ add_library(glm_static STATIC ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
 	${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER})
 	target_link_libraries(glm_static PUBLIC glm)
 	add_library(glm::glm_static ALIAS glm_static)
+	message(STATUS "Building GLM as static library")
+	
+	if(GLM_INSTALL)
+		install(
+			TARGETS glm_static 
+			EXPORT glm
+			LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+	endif()
 endif()
 
-if(BUILD_SHARED_LIBS)
+if(GLM_BUILD_SHARED_LIBS)
 add_library(glm_shared SHARED ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
 	${ROOT_SOURCE}    ${ROOT_INLINE}    ${ROOT_HEADER}
 	${CORE_SOURCE}    ${CORE_INLINE}    ${CORE_HEADER}
@@ -75,4 +85,14 @@ add_library(glm_shared SHARED ${ROOT_TEXT} ${ROOT_MD} ${ROOT_NAT}
 	${SIMD_SOURCE}    ${SIMD_INLINE}    ${SIMD_HEADER})
 	target_link_libraries(glm_shared PUBLIC glm)
 	add_library(glm::glm_shared ALIAS glm_shared)
+	message(STATUS "Building GLM as shared library")
+
+	if(GLM_INSTALL)
+		install(
+			TARGETS glm_shared 
+			EXPORT glm
+			LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+	endif()
 endif()


### PR DESCRIPTION
The issue found was that when using GLM via `FetchContent_Declare`, if different paths were specified in the call (i.e. src path, build path, etc). this would cause GLM to not properly install and would become invalid to projects attempting to use GLM in a non-header only fashion.

This PR accomplishes three things - 

1) This allows for determining if GLM is the root project or not.
- If it is, it will cause GLM to produce a standalone install. This is the same behaviour master branch has today.
- If not, it will only install if `GLM_INSTALL` is defined as `ON`. Similar to today's master branch, however it gives end-users the ability to still install the project.

2) This allows for determining _specifically_ if GLM will build as static or shared (or neither).

3) This allows for the static/shared versions of GLM to be installed.